### PR TITLE
fix typo in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ file). __The resulting formatted code will leave the parameter lists untouched._
 following modules, but most of the new syntax styles should work:
 
 - p5-mop
-- Method::Signature::Simple
+- Method::Signatures::Simple
 - MooseX::Method::Signatures
 - MooseX::Declare
 

--- a/lib/Perl/Tidy/Sweet.pm
+++ b/lib/Perl/Tidy/Sweet.pm
@@ -45,7 +45,7 @@ following modules, but most of the new syntax styles should work:
 
 =item * p5-mop
 
-=item * Method::Signature::Simple
+=item * Method::Signatures::Simple
 
 =item * MooseX::Method::Signatures
 

--- a/lib/Perl/Tidy/Sweetened.pm
+++ b/lib/Perl/Tidy/Sweetened.pm
@@ -102,7 +102,7 @@ following modules, but most of the new syntax styles should work:
 
 =item * p5-mop
 
-=item * Method::Signature::Simple
+=item * Method::Signatures::Simple
 
 =item * MooseX::Method::Signatures
 

--- a/script/perltidier
+++ b/script/perltidier
@@ -20,7 +20,7 @@ perltidier - Script to execute Perl::Tidy::Sweetened cleanup
 
 This script is a drop in replacement for L<Perl::Tidy>'s C<perltidy> which
 uses L<Perl::Tidy::Sweetened> to cleanup Perl code with a more "modern" syntax
-(ie, L<Method::Signature::Simple>, L<MooseX::Method::Signatures>,
+(ie, L<Method::Signatures::Simple>, L<MooseX::Method::Signatures>,
 L<MooseX::Declare>, etc).
 
 See the documentation for L<Perl::Tidy> and L<perltidy> for usage. See


### PR DESCRIPTION
Method::Signatures::Simple, not Method::Signature::Simple

---

I noticed this when trying clicking the link to 'Method::Signature::Simple' on the perltidier's POD page
