### PR TITLE
Support Kavorka's basic keywords

### DIFF
--- a/lib/Perl/Tidy/Sweet.pm
+++ b/lib/Perl/Tidy/Sweet.pm
@@ -56,6 +56,12 @@ following modules, but most of the new syntax styles should work:
 
 =item * MooseX::Declare
 
+=item * Moops
+
+=item * perl 5.20 signatures
+
+=item * Kavorka
+
 =back
 
 =head1 SEE ALSO

--- a/lib/Perl/Tidy/Sweetened.pm
+++ b/lib/Perl/Tidy/Sweetened.pm
@@ -37,6 +37,17 @@ $plugins->add_filter(
     ) );
 
 # Create a subroutine filter for:
+#    fun foo (Int $i) {}
+# where the parameter list is optional
+$plugins->add_filter(
+    Perl::Tidy::Sweetened::Keyword::Block->new(
+        keyword     => 'fun',
+        marker      => 'FUN',
+        replacement => 'sub',
+        clauses     => [ 'PAREN?' ],
+    ) );
+
+# Create a subroutine filter for:
 #    method foo (Int $i) returns (Bool) {}
 # where both the parameter list and the returns type are optional
 $plugins->add_filter(
@@ -45,6 +56,28 @@ $plugins->add_filter(
         marker      => 'METHOD',
         replacement => 'sub',
         clauses     => [ 'PAREN?', '(returns \s* PAREN)?' ],
+    ) );
+
+# Create a subroutine filter for:
+#    classmethod foo (Int $i) {}
+# where the parameter list is optional
+$plugins->add_filter(
+    Perl::Tidy::Sweetened::Keyword::Block->new(
+        keyword     => 'classmethod',
+        marker      => 'CLASSMETHOD',
+        replacement => 'sub',
+        clauses     => [ 'PAREN?' ],
+    ) );
+
+# Create a subroutine filter for:
+#    objectmethod foo (Int $i) {}
+# where the parameter list is optional
+$plugins->add_filter(
+    Perl::Tidy::Sweetened::Keyword::Block->new(
+        keyword     => 'objectmethod',
+        marker      => 'OBJECTMETHOD',
+        replacement => 'sub',
+        clauses     => [ 'PAREN?' ],
     ) );
 
 # Create a subroutine filter for:
@@ -126,9 +159,9 @@ following modules, but most of the new syntax styles should work:
 
 =item * Moops
 
-=item * MooseX::Declare
-
 =item * perl 5.20 signatures
+
+=item * Kavorka
 
 =back
 

--- a/script/perltidier
+++ b/script/perltidier
@@ -21,7 +21,7 @@ perltidier - Script to execute Perl::Tidy::Sweetened cleanup
 This script is a drop in replacement for L<Perl::Tidy>'s C<perltidy> which
 uses L<Perl::Tidy::Sweetened> to cleanup Perl code with a more "modern" syntax
 (ie, L<Method::Signatures::Simple>, L<MooseX::Method::Signatures>,
-L<MooseX::Declare>, etc).
+L<MooseX::Declare>, L<Kavorka> etc).
 
 See the documentation for L<Perl::Tidy> and L<perltidy> for usage. See
 L<Perl::Tidy::Sweetened> for more information about the changes introduced.

--- a/script/perltidy-sweet
+++ b/script/perltidy-sweet
@@ -21,7 +21,7 @@ perltidy-sweet - Script to execute Perl::Tidy::Sweetened cleanup
 This script is a drop in replacement for L<Perl::Tidy>'s C<perltidy> which
 uses L<Perl::Tidy::Sweetened> to cleanup Perl code with a more "modern" syntax
 (ie, L<Method::Signatures::Simple>, L<MooseX::Method::Signatures>,
-L<MooseX::Declare>, etc).
+L<MooseX::Declare>, L<Kavorka> etc).
 
 See the documentation for L<Perl::Tidy> and L<perltidy> for usage. See
 L<Perl::Tidy::Sweetened> for more information about the changes introduced.

--- a/t/kavorka.t
+++ b/t/kavorka.t
@@ -1,0 +1,173 @@
+use lib 't/lib';
+use Test::More;
+use TidierTests;
+
+run_test( <<'RAW', <<'TIDIED', 'Simple method usage', '',  );
+method name1{
+}
+sub name2{
+}
+RAW
+method name1 {
+}
+
+sub name2 {
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Simple methods with underscores ', '',  );
+method name_1{
+}
+RAW
+method name_1 {
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Method with signature', '',  );
+method name1 (class: $that) {
+}
+method name2( :$arg1, :$arg2 ){
+}
+sub name3 {}
+RAW
+method name1 (class: $that) {
+}
+
+method name2 ( :$arg1, :$arg2 ) {
+}
+sub name3 { }
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Simple classmethod usage', '',  );
+classmethod name1{
+}
+sub name2{
+}
+RAW
+classmethod name1 {
+}
+
+sub name2 {
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Simple classmethods with underscores ', '',  );
+classmethod name_1{
+}
+RAW
+classmethod name_1 {
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'classmethod with signature', '',  );
+classmethod name1 (class: $that) {
+}
+classmethod name2( :$arg1, :$arg2 ){
+}
+sub name3 {}
+RAW
+classmethod name1 (class: $that) {
+}
+
+classmethod name2 ( :$arg1, :$arg2 ) {
+}
+sub name3 { }
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Simple objectmethod usage', '',  );
+objectmethod name1{
+}
+sub name2{
+}
+RAW
+objectmethod name1 {
+}
+
+sub name2 {
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Simple objectmethods with underscores ', '',  );
+objectmethod name_1{
+}
+RAW
+objectmethod name_1 {
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'objectmethod with signature', '',  );
+objectmethod name1 (class: $that) {
+}
+objectmethod name2( :$arg1, :$arg2 ){
+}
+sub name3 {}
+RAW
+objectmethod name1 (class: $that) {
+}
+
+objectmethod name2 ( :$arg1, :$arg2 ) {
+}
+sub name3 { }
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Functions', '',  );
+fun morning ($name) {
+    say "Hi $name";
+}
+RAW
+fun morning ($name) {
+    say "Hi $name";
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Functions with underscore in name', '',  );
+fun morn_ing ($name) {
+    say "Hi $name";
+}
+RAW
+fun morn_ing ($name) {
+    say "Hi $name";
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'Functions with multi-line paramaters', '',  );
+fun morning ( Str :$name,
+              Int :$age,
+            ) {
+    say "Hi $name";
+}
+RAW
+fun morning ( Str :$name,
+              Int :$age,
+            ) {
+    say "Hi $name";
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'With trailing comments', '',  );
+method name1{# Trailing comment
+}
+sub name2{  # Trailing comment
+}
+RAW
+method name1 {    # Trailing comment
+}
+
+sub name2 {      # Trailing comment
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'With attribs trailing comments', '',  );
+method name1 :Attrib(Arg) {# comment
+}
+sub name2 :Attrib(Arg) {  # comment
+}
+RAW
+method name1 : Attrib(Arg) {    # comment
+}
+
+sub name2 : Attrib(Arg) {      # comment
+}
+TIDIED
+
+done_testing;


### PR DESCRIPTION
Adds support for `fun`, `objectmethod` and `classmethod` as they work in `Kavorka`. These are basically the same as how things already work but without optional `returns Foo` syntax

I also added a test file which is mostly just a copy of the `Method::Signatures::Simple` one. There's like a billion features in Kavorka so this isn't *technically* comprehensive but it seems to work okay

Test output

```
C:\Users\Peter Roberts\Documents\git_repos\Perl-Tidy-Sweetened>prove -l
t\00-version.t ................. # Perl::Tidy version: 20160302
t\00-version.t ................. ok
t\annon-func.t ................. ok
t\args-sbl.t ................... ok
t\basic.t ...................... ok
t\bugs.t ....................... ok
t\csc.t ........................ ok
t\kavorka.t .................... ok
t\method-signature-simple.t .... ok
t\moops.t ...................... ok
t\moosex-declare.t ............. ok
t\moosex-method-signatures.t ... ok
t\moosex-role-parameterized.t .. ok
t\p5-mop.t ..................... ok
t\perl-signatures.t ............ ok
All tests successful.

Test Summary Report
-------------------
t\bugs.t                     (Wstat: 0 Tests: 24 Failed: 0)
  TODO passed:   23-24
t\moops.t                    (Wstat: 0 Tests: 22 Failed: 0)
  TODO passed:   4, 16, 22
Files=14, Tests=177,  7 wallclock secs ( 0.16 usr +  0.01 sys =  0.17 CPU)
Result: PASS
```