### PR TITLE
Adding support for 'around'-keyword

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmp/
 Changes.bak
 log/tmp.log*
 _build_params
+cpanfile.snapshot
 
 .plenv-version
 local/

--- a/lib/Perl/Tidy/Sweetened.pm
+++ b/lib/Perl/Tidy/Sweetened.pm
@@ -61,14 +61,16 @@ $plugins->add_filter(
 
 # Create a subroutine filter for:
 #    around foo (Int $i) returns (Bool) {}
+#    before foo (Int $i) returns (Bool) {}
+#    after foo (Int $i) returns (Bool) {}
 # where both the parameter list and the returns type are optional
 $plugins->add_filter(
     Perl::Tidy::Sweetened::Keyword::Block->new(
-        keyword     => 'around',
-        marker      => 'AROUND',
+        keyword     => $_,
+        marker      => uc($_),
         replacement => 'sub',
         clauses     => ['PAREN?'],
-    ) );
+    ) ) for qw(around before after);
 
 # Create a subroutine filter for:
 #    classmethod foo (Int $i) {}

--- a/lib/Perl/Tidy/Sweetened.pm
+++ b/lib/Perl/Tidy/Sweetened.pm
@@ -60,6 +60,17 @@ $plugins->add_filter(
     ) );
 
 # Create a subroutine filter for:
+#    around foo (Int $i) returns (Bool) {}
+# where both the parameter list and the returns type are optional
+$plugins->add_filter(
+    Perl::Tidy::Sweetened::Keyword::Block->new(
+        keyword     => 'around',
+        marker      => 'AROUND',
+        replacement => 'sub',
+        clauses     => ['PAREN?'],
+    ) );
+
+# Create a subroutine filter for:
 #    classmethod foo (Int $i) {}
 # where the parameter list is optional
 $plugins->add_filter(

--- a/t/kavorka.t
+++ b/t/kavorka.t
@@ -176,4 +176,34 @@ RAW
 method foo () but begin { 'bar' }
 TIDIED
 
+run_test( <<'RAW', <<'TIDIED', 'around modifiers', '',  );
+around  foo(Str :$bar, Str :$baz?)   {
+say "hi";
+}
+RAW
+around foo (Str :$bar, Str :$baz?) {
+    say "hi";
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'before modifiers', '',  );
+before  foo(Str :$bar, Str :$baz?)   {
+say "hi";
+}
+RAW
+before foo (Str :$bar, Str :$baz?) {
+    say "hi";
+}
+TIDIED
+
+run_test( <<'RAW', <<'TIDIED', 'after modifiers', '',  );
+after foo(Str :$bar, Str :$baz?)   {
+say "hi";
+}
+RAW
+after foo (Str :$bar, Str :$baz?) {
+    say "hi";
+}
+TIDIED
+
 done_testing;


### PR DESCRIPTION
Hi, 

I had problems with code like this `around foo(Str :$bar, Str :$baz?)`
which was tidy'd to `around foo(Str : $bar, Str : $baz ?)`

My patch should fix that. Thanks