### PR TITLE
Adjust tests to Perl-Tidy-20200907

### DIFF
--- a/t/kavorka.t
+++ b/t/kavorka.t
@@ -144,7 +144,7 @@ fun morning ( Str :$name,
 }
 TIDIED
 
-run_test( <<'RAW', <<'TIDIED', 'With trailing comments', '',  );
+run_test( <<'RAW', <<"TIDIED", 'With trailing comments', '',  );
 method name1{# Trailing comment
 }
 sub name2{  # Trailing comment
@@ -153,11 +153,11 @@ RAW
 method name1 {    # Trailing comment
 }
 
-sub name2 {      # Trailing comment
+sub name2 {$indent# Trailing comment
 }
 TIDIED
 
-run_test( <<'RAW', <<'TIDIED', 'With attribs trailing comments', '',  );
+run_test( <<'RAW', <<"TIDIED", 'With attribs trailing comments', '',  );
 method name1 :Attrib(Arg) {# comment
 }
 sub name2 :Attrib(Arg) {  # comment
@@ -166,7 +166,7 @@ RAW
 method name1 : Attrib(Arg) {    # comment
 }
 
-sub name2 : Attrib(Arg) {      # comment
+sub name2 : Attrib(Arg) {$indent# comment
 }
 TIDIED
 

--- a/t/lib/TidierTests.pm
+++ b/t/lib/TidierTests.pm
@@ -7,7 +7,7 @@ use Test::Most;
 
 use Exporter;
 @TidierTests::ISA    = qw(Exporter);
-@TidierTests::EXPORT = qw(run_test);
+@TidierTests::EXPORT = qw(run_test $indent);
 
 sub run_test {
     my ( $raw, $expected, $msg, $todo, @args ) = @_;
@@ -49,5 +49,8 @@ sub check_test {
 
     return $ok_log && $ok_tidy;
 }
+
+require Perl::Tidy;
+our $indent = ' ' x (($Perl::Tidy::VERSION < 20200907) ? 6 : 4);
 
 1;

--- a/t/method-signature-simple.t
+++ b/t/method-signature-simple.t
@@ -72,7 +72,7 @@ func morning ( Str :$name,
 }
 TIDIED
 
-run_test( <<'RAW', <<'TIDIED', 'With trailing comments', '',  );
+run_test( <<'RAW', <<"TIDIED", 'With trailing comments', '',  );
 method name1{# Trailing comment
 }
 sub name2{  # Trailing comment
@@ -81,11 +81,11 @@ RAW
 method name1 {    # Trailing comment
 }
 
-sub name2 {      # Trailing comment
+sub name2 {$indent# Trailing comment
 }
 TIDIED
 
-run_test( <<'RAW', <<'TIDIED', 'With attribs trailing comments', '',  );
+run_test( <<'RAW', <<"TIDIED", 'With attribs trailing comments', '',  );
 method name1 :Attrib(Arg) {# comment
 }
 sub name2 :Attrib(Arg) {  # comment
@@ -94,7 +94,7 @@ RAW
 method name1 : Attrib(Arg) {    # comment
 }
 
-sub name2 : Attrib(Arg) {      # comment
+sub name2 : Attrib(Arg) {$indent# comment
 }
 TIDIED
 


### PR DESCRIPTION
Perl-Tidy-20200907 changed an indentation of side comments. This patch
adjusts the tests.

https://github.com/mvgrimes/Perl-Tidy-Sweetened/issues/18