### PR TITLE
- anchor end of closing-commit replace-string to handle 10+ subs

### DIFF
--- a/lib/Perl/Tidy/Sweetened.pm
+++ b/lib/Perl/Tidy/Sweetened.pm
@@ -158,6 +158,9 @@ keywords (see the 2010-12-17 entry in the Perl::Tidy
 L<CHANGES|https://metacpan.org/source/SHANCOCK/Perl-Tidy-20120714/CHANGES>
 file). B<The resulting formatted code will leave the parameter lists untouched.>
 
+For handling of closing-side-comments (at end of sub/method/function) you must
+use perltidy with the default of --csc='## end'.
+
 C<Perl::Tidy::Sweetened> attempts to support the syntax outlined in the
 following modules, but most of the new syntax styles should work:
 


### PR DESCRIPTION
- anchor end of closing-commit replace-string to handle 10+ subs
- closing comment handling requires specific csc string, updated doc
- noted hard adding of space between sub/method name and clauses

(had trouble finding cause of the unwanted space, but no nice flexible
solution for it yet)